### PR TITLE
Change migration guide for 1.0.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,8 @@ toc::[]
 
 === Changed
 
+* Migration guide for 1.0.0 to include FHIR model property order change
+
 === Removed
 
 === Fixed

--- a/MIGRATION.adoc
+++ b/MIGRATION.adoc
@@ -55,7 +55,7 @@ CodeSystems.AddressType.POSTAL -> CodeSystemAddressType.POSTAL
 
 In our 0.7.0 version all FHIR Model properties have been in alphabetical order, this was not according the FHIR specification.
 
-From version 1.0.0 on properties are in the correct order. This could be problematic if the same property type changed positions, e.g. for [DocumentReference](http://hl7.org/fhir/STU3/documentreference.html)
+From version 1.0.0 on properties are in the correct order. This could be problematic if the same property type changed positions, e.g. for link:http://hl7.org/fhir/STU3/documentreference.html[DocumentReference]
 
 [source, java]
 ----

--- a/MIGRATION.adoc
+++ b/MIGRATION.adoc
@@ -6,12 +6,16 @@ to another.
 [#migration-0_7_0-1_0_0]
 == Migrate from Version 0.7.0 to 1.0.0
 
+
+=== CodeSystems
+
 In version 0.7.0 the `CodeSystems` was a big `enum` that contains the
 individual `CodeSystems` for the different classes. With the new version
 1.0.0 the `CodeSystems` are now stand alone classes.
 
 In detail the change for the CodeSystems looks like the following:
 
+[source, java]
 ----
 // v0.7.0 
 public class CodeSystems {
@@ -27,6 +31,7 @@ public class CodeSystems {
 In version 1.0.0 each CodeSystem will be it's own standalone enum class
 with the naming pattern `CodeSystem...` e.g.
 
+[source, java]
 ----
 // v1.0.0 
 public enum CodeSystemAbstracType { }    
@@ -37,10 +42,28 @@ public enum CodeSystemAddressType { }
 In case you made use of the `CodeSystems` you need to update the imports
 to th specific CodeSystem class.
 
+[source, java]
 ----
 CodeSystems.AbstractType.ANY -> CodeSystemAbstractType.ANY
 CodeSystems.AccountStatus.INACTIVE -> CodeSystemAccountStatus.INACTIVE
-...
+// ...
 CodeSystems.AddressType.POSTAL -> CodeSystemAddressType.POSTAL
-...
+// ...
 ----
+
+=== FHIR Model property order
+
+In our 0.7.0 version all FHIR Model properties have been in alphabetical order, this was not according the FHIR specification.
+
+From version 1.0.0 on properties are in the correct order. This could be problematic if the same property type changed positions, e.g. for [DocumentReference](http://hl7.org/fhir/STU3/documentreference.html)
+
+[source, java]
+----
+new DocumentReference(..., Identifier identifier, Identifier masterIdentifier, ...)
+
+// changed to
+
+new DocumentReference(Identifier masterIdentifier, Identifier identifier, ...)
+----
+
+Ideally this is covered by tests.


### PR DESCRIPTION
## Description
Change migration guide for 1.0.0 to include changed FHIR model property order

## Motivation and Context
FHIR model property order changed from alphabetical to FHIR defined order with update 0.7.0 to 1.0.0

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
