### PR TITLE
Fix Canonical

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,10 +17,12 @@ toc::[]
 === Added
 
 === Changed
+* Canonical(R4): had been aligned with the other classes of the repo
 
 === Removed
 
 === Fixed
+* CanonicalJsonAdapter#toJson(R4): it accesses `value` of a writer now only once
 
 === Bumped
 

--- a/fhir-java/src/main/java/care/data4life/fhir/r4/json/CanonicalJsonAdapter.java
+++ b/fhir-java/src/main/java/care/data4life/fhir/r4/json/CanonicalJsonAdapter.java
@@ -23,10 +23,12 @@ import com.squareup.moshi.JsonWriter;
 import java.io.IOException;
 
 import javax.annotation.Nullable;
+import javax.annotation.RegEx;
 
 import care.data4life.fhir.r4.model.Canonical;
 
 public class CanonicalJsonAdapter extends JsonAdapter<Canonical> {
+    private final static String DELIMITER = "|";
 
     @Nullable
     @Override
@@ -36,21 +38,25 @@ public class CanonicalJsonAdapter extends JsonAdapter<Canonical> {
         }
         String value = reader.nextString();
         if (value.contains("|")) {
-            String[] result = value.split("\\|");
+            String[] result = value.split("\\" + DELIMITER);
             return new Canonical(result[0], result[1]);
         }
 
         return new Canonical(value);
     }
 
+    private String buildUrl(Canonical canonical) {
+        if (canonical.version != null && !canonical.version.isEmpty()) {
+            return canonical.url + DELIMITER + canonical.version;
+        } else {
+            return canonical.url;
+        }
+    }
+
     @Override
     public void toJson(JsonWriter writer, @Nullable Canonical value) throws IOException {
         if (value != null) {
-            writer.value(value.url);
-            if (value.version != null && !value.version.isEmpty()) {
-                writer.value("|");
-                writer.value(value.version);
-            }
+            writer.value(buildUrl(value));
         } else {
             writer.nullValue();
         }

--- a/fhir-java/src/main/java/care/data4life/fhir/r4/json/CanonicalJsonAdapter.java
+++ b/fhir-java/src/main/java/care/data4life/fhir/r4/json/CanonicalJsonAdapter.java
@@ -19,12 +19,8 @@ package care.data4life.fhir.r4.json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
-
 import java.io.IOException;
-
 import javax.annotation.Nullable;
-import javax.annotation.RegEx;
-
 import care.data4life.fhir.r4.model.Canonical;
 
 public class CanonicalJsonAdapter extends JsonAdapter<Canonical> {

--- a/fhir-java/src/main/java/care/data4life/fhir/r4/model/Canonical.java
+++ b/fhir-java/src/main/java/care/data4life/fhir/r4/model/Canonical.java
@@ -16,6 +16,10 @@
 
 package care.data4life.fhir.r4.model;
 
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
 /**
  * Canonical.java
  * <p>
@@ -46,8 +50,28 @@ public class Canonical {
         this.version = version;
     }
 
+    public String getUrl() {
+        return url;
+    }
+
+    @Nullable
+    public String getVersion() {
+        return version;
+    }
+
     public String getResourceType() {
         return resourceType;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Canonical other = (Canonical) o;
+
+        return url.equals(other.url) && Objects.equals(version, other.version);
+    }
+
+    @Override
+    public int hashCode() { return Objects.hash(url, version); }
 }

--- a/fhir-java/src/main/java/care/data4life/fhir/r4/model/Canonical.java
+++ b/fhir-java/src/main/java/care/data4life/fhir/r4/model/Canonical.java
@@ -17,7 +17,6 @@
 package care.data4life.fhir.r4.model;
 
 import java.util.Objects;
-
 import javax.annotation.Nullable;
 
 /**

--- a/fhir-java/src/test/java/care/data4life/fhir/r4/json/CanonicalJsonAdapterTest.java
+++ b/fhir-java/src/test/java/care/data4life/fhir/r4/json/CanonicalJsonAdapterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.r4.json;
+
+import com.squareup.moshi.JsonAdapter;
+import org.junit.Before;
+import org.junit.Test;
+import java.io.IOException;
+import care.data4life.fhir.r4.model.Canonical;
+import static org.junit.Assert.assertEquals;
+
+public class CanonicalJsonAdapterTest {
+    private final static String URL = "http://fhir.smart4health.eu/Questionnaire/post-session-questionnaire";
+    private final static String DELIMITER = "|";
+    private final static String VERSION = "0.1.0";
+
+    // SUT
+    private JsonAdapter<Canonical> adapter;
+
+
+    @Before
+    public void setup() {
+        adapter = new CanonicalJsonAdapter().lenient();
+    }
+
+    @Test
+    public void given_fromJson_is_called_with_a_url_and_without_a_version_it_returns_a_Canonical()
+            throws IOException {
+        assertEquals(
+                adapter.fromJson("\"" + URL + "\""),
+                new Canonical(URL)
+        );
+    }
+
+    @Test
+    public void given_fromJson_is_called_with_a_url_and_wit_a_version_it_returns_a_Canonical() throws Exception {
+        assertEquals(
+                adapter.fromJson("\"" + URL + DELIMITER + VERSION + "\""),
+                new Canonical(URL, VERSION)
+        );
+    }
+
+    @Test
+    public void given_toJson_is_called_with_a_Canonical_which_contains_no_version_it_serializes_it() {
+        assertEquals(
+                adapter.toJson(new Canonical(URL)),
+                "\"" + URL + "\""
+        );
+    }
+
+    @Test
+    public void given_toJson_is_called_with_a_Canonical_which_contains_version_it_serializes_it() {
+        assertEquals(
+                adapter.toJson(new Canonical(URL, VERSION)),
+                "\"" + URL + DELIMITER + VERSION + "\""
+        );
+    }
+
+    @Test
+    public void given_toJson_is_called_with_it_writes_null() {
+        assertEquals("null", adapter.toJson(null));
+    }
+}

--- a/fhir-java/src/test/java/care/data4life/fhir/r4/json/CanonicalJsonAdapterTest.java
+++ b/fhir-java/src/test/java/care/data4life/fhir/r4/json/CanonicalJsonAdapterTest.java
@@ -37,6 +37,7 @@ public class CanonicalJsonAdapterTest {
         adapter = new CanonicalJsonAdapter().lenient();
     }
 
+    
     @Test
     public void given_fromJson_is_called_with_a_url_and_without_a_version_it_returns_a_Canonical()
             throws IOException {

--- a/fhir-java/src/test/java/care/data4life/fhir/r4/model/CanonicalTest.java
+++ b/fhir-java/src/test/java/care/data4life/fhir/r4/model/CanonicalTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.r4.model;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class CanonicalTest {
+
+    private static final String URL = "https://theway.to/go";
+    private static final String VERSION = "NX-42";
+    private static final String RESOURCE_TYPE = "Canonical";
+
+
+    // Canonical
+    Canonical canonical;
+
+
+    @Before
+    public void setup() {
+        canonical = new Canonical(URL, VERSION);
+    }
+
+
+    @Test
+    public void it_contains_a_url() { assertEquals(URL, canonical.url); }
+
+    @Test
+    public void it_contains_a_version() { assertEquals(VERSION, canonical.version); }
+
+    @Test
+    public void it_contains_a_resourceType() { assertEquals(RESOURCE_TYPE, canonical.getResourceType()); }
+
+    @Test
+    public void given_another_canonical_equals_it_returns_true() {
+        Canonical expected = new Canonical(URL, VERSION);
+        assertEquals(expected, expected);
+    }
+
+    @Test
+    public void given_hash_is_called_it_returns_a_stable_hashcode() {
+        assertEquals(-1407719353, canonical.hashCode());
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes the issue with [Canonical](http://hl7.org/fhir/R4/datatypes.html#canonical).

## Motivation and Context
Currently Canonicals are breaking the JSON, since `writer.value` is called multiple times during the serialization.

## How is it being implemented?
This PR aligns Canonical and CanonicalJsonAdapter with our current shema and refactors CanonicalJsonAdapter in a way, that `writer.value` is called just once.

## How Has This Been Tested?
2 new testsets are added, since Canonical and CanonicalJsonAdapter are not been tested so far.
For CanonicalJsonAdapter both branches (with and without version) had been tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
