### PR TITLE
Fix Maven deployment

### DIFF
--- a/buildSrc/src/main/kotlin/scripts/publishing-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/publishing-config.gradle.kts
@@ -30,12 +30,12 @@ tasks.named<JacocoReport>("jacocoTestReport") {
 
 tasks.register<Jar>("sourcesJar") {
     from(sourceSets.main.get().allSource)
-    classifier = "sources"
+    archiveClassifier.set("sources")
 }
 
 tasks.register<Jar>("javadocJar") {
     from(tasks.javadoc)
-    classifier = "javadoc"
+    archiveClassifier.set("javadoc")
 }
 
 tasks.javadoc {
@@ -74,7 +74,7 @@ publishing {
     }
 
     publications {
-        withType<MavenPublication> {
+        create<MavenPublication>("jvm") {
             groupId = ProjectConfig.library.publish.groupId
 
             from(components["java"])


### PR DESCRIPTION
## Description
Fix maven deployment by changing `withType<MavenPublication>` to `create<MavenPublication>("jvm")` as the `java-library` Gradle plugin doesn't come with a default maven publish config

## Motivation and Context
Maven deployment task is not publishing anything

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
