### PR TITLE
Make FhirElementFactory#getClassForFhirType case insensitive

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,8 @@ toc::[]
 
 === Changed
 
+* FhirElementFactory#getClassForFhirType is now case insensitive.
+
 === Removed
 
 === Fixed

--- a/fhir-java/parser/r4/templates/template-elementfactory.java
+++ b/fhir-java/parser/r4/templates/template-elementfactory.java
@@ -54,9 +54,9 @@ public final class FhirElementFactory {
   }
 
   public static Class<?> getClassForFhirType(String typeName) {
-    switch (typeName) {
+    switch (typeName.toLowerCase()) {
       {%- for klass in classes %}{%if klass.name in resource_list %}
-      case "{{ klass.resource_type }}":
+      case "{{ klass.resource_type.lower() }}":
         return {{ klass.name }}.class;
       {%-endif %}{% endfor %}
 

--- a/fhir-java/parser/r4/templates/template-unittest-factory.java
+++ b/fhir-java/parser/r4/templates/template-unittest-factory.java
@@ -73,7 +73,7 @@ public class {{ class.name }}FhirElementFactory {
         public void getClassForFhirTypeTest () throws Exception {
         {%- for klass in classes %}{% if klass.name in resource_list %}
         if(clazz == {{ klass.name }}.class){
-        assertEquals(getClassForFhirType({{ klass.resource_type }}.resourceType), klass);
+        assertEquals(getClassForFhirType({{ klass.resource_type }}.resourceType.toUpperCase()), klass);
         }
         {%- endif %}{% endfor %}
         }

--- a/fhir-java/parser/stu3/templates/template-elementfactory.java
+++ b/fhir-java/parser/stu3/templates/template-elementfactory.java
@@ -50,9 +50,9 @@ public final class FhirElementFactory {
   }
 
   public static Class<?> getClassForFhirType(String typeName) {
-    switch (typeName) {
+    switch (typeName.toLowerCase()) {
       {%- for klass in classes %}{%if klass.name in resource_list %}
-      case "{{ klass.resource_type }}":
+      case "{{ klass.resource_type.lower() }}":
         return {{ klass.name }}.class;
       {%-endif %}{% endfor %}
 

--- a/fhir-java/parser/stu3/templates/template-unittest-factory.java
+++ b/fhir-java/parser/stu3/templates/template-unittest-factory.java
@@ -69,7 +69,7 @@ public class {{ class.name }}FhirElementFactory {
         public void getClassForFhirTypeTest () throws Exception {
         {%- for klass in classes %}{% if klass.name in resource_list %}
         if(clazz == {{ klass.name }}.class){
-        assertEquals(getClassForFhirType({{ klass.resource_type }}.resourceType), klass);
+        assertEquals(getClassForFhirType({{ klass.resource_type }}.resourceType.toUpperCase()), klass);
         }
         {%- endif %}{% endfor %}
         }

--- a/fhir-java/src-gen/main/java/care/data4life/fhir/r4/model/FhirElementFactory.java
+++ b/fhir-java/src-gen/main/java/care/data4life/fhir/r4/model/FhirElementFactory.java
@@ -93,52 +93,52 @@ public final class FhirElementFactory {
     }
 
     public static Class<?> getClassForFhirType(String typeName) {
-        switch (typeName) {
-            case "CarePlan":
+        switch (typeName.toLowerCase()) {
+            case "careplan":
                 return CarePlan.class;
-            case "CareTeam":
+            case "careteam":
                 return CareTeam.class;
-            case "Condition":
+            case "condition":
                 return Condition.class;
-            case "DiagnosticReport":
+            case "diagnosticreport":
                 return DiagnosticReport.class;
-            case "DocumentReference":
+            case "documentreference":
                 return DocumentReference.class;
-            case "Encounter":
+            case "encounter":
                 return Encounter.class;
-            case "FamilyMemberHistory":
+            case "familymemberhistory":
                 return FamilyMemberHistory.class;
-            case "Goal":
+            case "goal":
                 return Goal.class;
-            case "Location":
+            case "location":
                 return Location.class;
-            case "Medication":
+            case "medication":
                 return Medication.class;
-            case "MedicationRequest":
+            case "medicationrequest":
                 return MedicationRequest.class;
-            case "Observation":
+            case "observation":
                 return Observation.class;
-            case "Organization":
+            case "organization":
                 return Organization.class;
-            case "Patient":
+            case "patient":
                 return Patient.class;
-            case "Practitioner":
+            case "practitioner":
                 return Practitioner.class;
-            case "Procedure":
+            case "procedure":
                 return Procedure.class;
-            case "Provenance":
+            case "provenance":
                 return Provenance.class;
-            case "Questionnaire":
+            case "questionnaire":
                 return Questionnaire.class;
-            case "QuestionnaireResponse":
+            case "questionnaireresponse":
                 return QuestionnaireResponse.class;
-            case "ServiceRequest":
+            case "servicerequest":
                 return ServiceRequest.class;
-            case "Specimen":
+            case "specimen":
                 return Specimen.class;
-            case "Substance":
+            case "substance":
                 return Substance.class;
-            case "ValueSet":
+            case "valueset":
                 return ValueSet.class;
 
             default:

--- a/fhir-java/src-gen/main/java/care/data4life/fhir/stu3/model/FhirElementFactory.java
+++ b/fhir-java/src-gen/main/java/care/data4life/fhir/stu3/model/FhirElementFactory.java
@@ -90,50 +90,50 @@ public final class FhirElementFactory {
     }
 
     public static Class<?> getClassForFhirType(String typeName) {
-        switch (typeName) {
-            case "CarePlan":
+        switch (typeName.toLowerCase()) {
+            case "careplan":
                 return CarePlan.class;
-            case "CareTeam":
+            case "careteam":
                 return CareTeam.class;
-            case "Condition":
+            case "condition":
                 return Condition.class;
-            case "DiagnosticReport":
+            case "diagnosticreport":
                 return DiagnosticReport.class;
-            case "DocumentReference":
+            case "documentreference":
                 return DocumentReference.class;
-            case "FamilyMemberHistory":
+            case "familymemberhistory":
                 return FamilyMemberHistory.class;
-            case "Goal":
+            case "goal":
                 return Goal.class;
-            case "Medication":
+            case "medication":
                 return Medication.class;
-            case "MedicationRequest":
+            case "medicationrequest":
                 return MedicationRequest.class;
-            case "Observation":
+            case "observation":
                 return Observation.class;
-            case "Organization":
+            case "organization":
                 return Organization.class;
-            case "Patient":
+            case "patient":
                 return Patient.class;
-            case "Practitioner":
+            case "practitioner":
                 return Practitioner.class;
-            case "Procedure":
+            case "procedure":
                 return Procedure.class;
-            case "ProcedureRequest":
+            case "procedurerequest":
                 return ProcedureRequest.class;
-            case "Provenance":
+            case "provenance":
                 return Provenance.class;
-            case "Questionnaire":
+            case "questionnaire":
                 return Questionnaire.class;
-            case "QuestionnaireResponse":
+            case "questionnaireresponse":
                 return QuestionnaireResponse.class;
-            case "ReferralRequest":
+            case "referralrequest":
                 return ReferralRequest.class;
-            case "Specimen":
+            case "specimen":
                 return Specimen.class;
-            case "Substance":
+            case "substance":
                 return Substance.class;
-            case "ValueSet":
+            case "valueset":
                 return ValueSet.class;
 
             default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This makes the type names for FhirElementFactory#getClassForFhirType case insensitive.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 Currently the type names are case sensitive, which is not needed. However this causes the SDK to keep track of the actual resources, which it should not.

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
Simply by lowercase the input as well as the case statements in the switch loop of the method.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Currently the automated tests are not generated, but the unittest-template had been adjusted to cover that. However manual tests had been conducted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
